### PR TITLE
support packaging files named with multiple dots

### DIFF
--- a/src/nap.coffee
+++ b/src/nap.coffee
@@ -184,7 +184,7 @@ precompile = (pkg, type) =>
         .use(nib())
         .render (err, out) -> contents = out
     
-    outputFilename = filename.replace /\..*/, '' + '.' + type
+    outputFilename = filename.replace /\.[^.]*$/, '' + '.' + type
     hash[outputFilename] = contents
   hash
 

--- a/test/fixtures/1/foo.bar.js
+++ b/test/fixtures/1/foo.bar.js
@@ -1,0 +1,1 @@
+var foo = 'foo';

--- a/test/nap_spec.coffee
+++ b/test/nap_spec.coffee
@@ -64,7 +64,7 @@ describe 'running the `js` function', ->
     nap.js('foo').should
       .equal "<script src='/assets/test/fixtures/1/bar.js' type='text/javascript'></script>"
   
-  it 'throw an error if the package doesnt exists', ->
+  it 'throw an error if the package doesnt exist', ->
     nap
       assets:
         js:
@@ -82,7 +82,14 @@ describe 'running the `js` function', ->
           bar: ['test/fixtures/1/bar.coffee']
     nap.js('bar').should
       .equal "<script src='/assets/test/fixtures/1/bar.js' type='text/javascript'></script>"
-      
+  
+  it "can handle filenames with periods", ->
+    nap
+      assets:
+        js:
+          bar: ['/test/fixtures/1/foo.bar.js']
+    nap.js('bar').should.equal "<script src='/assets/test/fixtures/1/foo.bar.js' type='text/javascript'></script>"
+
   describe 'in development mode', ->
     
     it 'compiles any coffeescript files into js', ->


### PR DESCRIPTION
The package process would mis-handle files that have multiple dots in their names. E.g.:

```
@js =
  vendor: [
    '/app/vendor/plugins/jquery.fileupload.js'
    '/app/vendor/plugins/jquery.fileuploadui.js'
  ]
```

When compiled, the first file's contents would be ignored, and only the 2nd would be included (in development mode, in a single "jquery.js" file).
