### PR TITLE
Fix for colliding fingerprints.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "should": "*",
     "wrench": "*",
     "jade": "*",
-    "hogan": "*",
+    "hogan.js": "*",
     "stylus": "*",
     "less": "*",
     "nib": "*"

--- a/test/nap_spec.coffee
+++ b/test/nap_spec.coffee
@@ -156,7 +156,7 @@ describe '#js', ->
         assets:
           js:
             baz: ['/test/fixtures/1/bar.coffee', '/test/fixtures/1/foo.js']
-      
+      nap.package()
       nap.js('baz').should.include "<script src='/assets/baz"
       
     it 'returns a script tag pointing to the CDN packaged file', ->
@@ -166,7 +166,7 @@ describe '#js', ->
         assets:
           js:
             baz: ['/test/fixtures/1/bar.coffee', '/test/fixtures/1/foo.js']
-      
+      nap.package()
       nap.js('baz').should.include "<script src='http://cdn.com/baz"
     
     it 'points to the 
@@ -177,7 +177,7 @@ describe '#js', ->
         assets:
           js:
             baz: ['/test/fixtures/1/bar.coffee', '/test/fixtures/1/foo.js']
-      
+      nap.package()
       nap.js('baz').should.include "<script src='/assets/baz"
     
     it 'doesnt have to point to the gzipped file', ->
@@ -187,7 +187,7 @@ describe '#js', ->
         assets:
           js:
             baz: ['/test/fixtures/1/bar.coffee', '/test/fixtures/1/foo.js']
-      
+      nap.package()
       nap.js('baz', false).should.include "<script src='/assets/baz"
     
     it 'gzips assets that have a fingerprint'
@@ -308,7 +308,7 @@ describe '#css', ->
         assets:
           css:
             baz: ['/test/fixtures/1/bar.css']
-      
+      nap.package()
       nap.css('baz').should.include "<link href=\'/assets/baz"
       
     it 'returns a link tag pointing to the CDN packaged file', ->
@@ -318,7 +318,7 @@ describe '#css', ->
         assets:
           css:
             baz: ['/test/fixtures/1/bar.css']
-      
+      nap.package()
       nap.css('baz').should.include "<link href=\'http://cdn.com/baz"
     
     it 'points to the gzipped file if specified', ->
@@ -328,7 +328,7 @@ describe '#css', ->
         assets:
           css:
             baz: ['/test/fixtures/1/bar.css']
-      
+      nap.package()
       nap.css('baz').should.include "<link href=\'/assets/baz"
       
 describe '#jst', ->
@@ -435,7 +435,7 @@ describe '#jst', ->
         assets:
           jst:
             foo: ['/test/fixtures/1/foo.jade']
-      
+      nap.package()
       nap.jst('foo').should.include "<script src='/assets/foo"
       
     it 'points to the cdn if specified', ->
@@ -445,7 +445,7 @@ describe '#jst', ->
         assets:
           jst:
             foo: ['/test/fixtures/1/foo.jade']
-      
+      nap.package()
       nap.jst('foo').should.include "<script src='http://cdn.com/foo"
      
     it 'points to the gzipped file if specified', ->
@@ -455,7 +455,7 @@ describe '#jst', ->
         assets:
           jst:
             foo: ['/test/fixtures/1/foo.jade']
-      
+      nap.package()
       nap.jst('foo').should.include "<script src='/assets/foo"
      
         


### PR DESCRIPTION
Currently fingerprintForPkg is applied to the source asset files, before any preprocessors are applied. This breaks Stylus files, since they can import content from other files, resulting in a different processed file when the source assets nap knows about haven't changed.

Fingerprints should be generated against the final versions of the file.

This patch does that. As a side effect, it enforces that nap.package() must be called before production assets can be used.

(also clean up to using "hogan.js" as a dependency rather than "hogan" since that's what npm knows.)
(unit tests claiming mode:"production" have been updated to call nap.package() consistently.)
