### PR TITLE
Add support for combined templates

### DIFF
--- a/test/fixtures/1/foo.mustache.jade
+++ b/test/fixtures/1/foo.mustache.jade
@@ -1,0 +1,1 @@
+h1 Hello {{world}}

--- a/test/nap_spec.coffee
+++ b/test/nap_spec.coffee
@@ -456,7 +456,19 @@ describe '#jst', ->
               foo: ['/test/fixtures/1/foo.mustache']
         nap.jst('foo')
         fs.readFileSync(process.cwd() + '/public/assets/foo.jst.js').toString()
-          .should.include "<h1>Hello"
+          .should.include "<h1>Hello"    
+
+    describe 'using combined mustache and jade templates', ->
+      
+      it 'compiles .mustache.jade templates into JST functions', ->
+        nap
+          assets:
+            jst:
+              foo: ['/test/fixtures/1/foo.mustache.jade']
+        nap.jst('foo')
+        template = fs.readFileSync(process.cwd() + '/public/assets/foo.jst.js').toString()
+        template.should.include "<h1>Hello"
+        template.should.not.include "{{world}}"
         
   describe 'in production', ->
   


### PR DESCRIPTION
This commit adds support for adding parsers for combined templates. For example, one could combined Jade with Mustache and name the file foo.mustache.jade (so that it's not necessary to write plain old html):

``` jade
tr
  td.title {{title}}
  td.price {{price}}
  td.quantity {{quantity}}
  td.discountRate {{discountRate}}
  td.taxRate {{taxRate}}
  td.total {{total}}
```

What this commit does is that instead of having to use custom file extensions like `foo.mustachejade`, you can combine them like this: `foo.mustache.jade` and let nap figure out that it should use the `.mustache.jade` parser instead of the `.jade` parser. This allows to keep syntax highlighting working in your text editor and keeps the filename semantics cleaner.
