### PR TITLE
Don't override window.JST

### DIFF
--- a/lib/nap.coffee
+++ b/lib/nap.coffee
@@ -38,7 +38,7 @@ module.exports = (options = {}) =>
     else 'development'
   @cdnUrl = if options.cdnUrl? then options.cdnUrl.replace /\/$/, '' else undefined
   @gzip = options.gzip ? false
-  @_tmplPrefix = 'window.JST = {};\n'
+  @_tmplPrefix = 'window.JST = window.JST || {};\n'
   @_assetsDir = '/assets'
   @_outputDir = path.normalize @publicDir + @_assetsDir
   @_fileMtimeMap = {}


### PR DESCRIPTION
This commit addresses an issue where window.JST may be defined before and templates-prefix.js file overrides it by creating an empty object. 
