### PR TITLE
Specify all dependency versions with less granularity.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nap",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "author": {
     "name": "Craig Spaeth",
     "email": "craigspaeth@gmail.com",
@@ -23,25 +23,25 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "coffee-script": "~1.4.0",
-    "underscore": "~1.4.2",
-    "underscore.string": "~2.3.0",
-    "uglify-js": "~2.2.1",
-    "sqwish": "~0.2.0",
-    "mkdirp": "~0.3.4",
-    "file": "~0.2.1",
-    "glob": "~3.1.14",
-    "rimraf": "~2.0.2"
+    "coffee-script": "~1",
+    "underscore": "~1",
+    "underscore.string": "~2",
+    "uglify-js": "~2",
+    "sqwish": ">= 0.2.0",
+    "mkdirp": ">= 0.3.4",
+    "file": ">= 0.2.1",
+    "glob": "~3",
+    "rimraf": "~2"
   },
   "devDependencies": {
-    "mocha": "~1.7.1",
-    "should": "~1.2.1",
-    "wrench": "~1.4.3",
-    "jade": "~0.27.7",
-    "hogan.js": "~2.0.0",
-    "stylus": "~0.31.0",
-    "less": "~1.3.1",
-    "nib": "~0.9.0"
+    "mocha": "~1",
+    "should": "~1",
+    "wrench": "~1",
+    "jade": ">= 0.27.7",
+    "hogan.js": "~2",
+    "stylus": ">= 0.31.0",
+    "less": "~1",
+    "nib": ">= 0.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is intended to address a dependency conflict in an app whose other dependencies require versions of Nap's dependencies greater than the ones to which it's pinned. The general idea here is to fully trust semantic versioning rules for post-1.0.0 versions (i.e., assuming that all versions within a major version number will be backwards-compatible), and going a bit Wild West on pre-1.0.0 versions (simply setting a minimum version requirement).

I can point out the specific problem dependencies and isolate the changes to those if that's preferable.
