### PR TITLE
Use semicolon to join js files.

### DIFF
--- a/lib/nap.coffee
+++ b/lib/nap.coffee
@@ -142,7 +142,7 @@ module.exports.package = (callback = ->) =>
   
   if @assets.js?
     for pkg, files of @assets.js
-      contents = (contents for fn, contents of preprocessPkg pkg, 'js').join('\n')
+      contents = (contents for fn, contents of preprocessPkg pkg, 'js').join(';\n')
       contents = uglify contents if @mode is 'production' and @minify
       fingerprint = '-' + fingerprintForPkg('js', pkg)
       filename = "#{pkg}#{fingerprint ? ''}.js"


### PR DESCRIPTION
This fixes problems that sometimes occur when js files don't end with semicolons. It doesn't have any adverse affects if the files do end with a semicolon, since `;;` is valid javascript (it creates an empty statement inbetween the semicolons).

For an example, see https://github.com/jezdez/django_compressor/issues/319
