### PR TITLE
Added optional appDir option to don't depend on the cwd.

### DIFF
--- a/lib/nap.coffee
+++ b/lib/nap.coffee
@@ -28,10 +28,10 @@ module.exports = (options = {}) =>
     throw new Error "You must specify an 'assets' obj with keys 'js', 'css', or 'jst'"
   @assets = _.clone options.assets
   @originalAssets = _.clone options.assets
+  @appDir = (if options.appDir? then options.appDir else process.cwd())
   expandAssetGlobs()
 
   # Config defaults
-  @appDir = (if options.appDir? then options.appDir else process.cwd())
   @publicDir = path.resolve(@appDir, options.publicDir || 'public')
   @mode = options.mode ? switch process.env.NODE_ENV
     when 'staging' then 'production'


### PR DESCRIPTION
The working directory of my main program is 

```
/something/main-prog
```

 but the plugin which uses nap is under 

```
/something/some-plugin
```

and I don't want to change the cwd to the plugin folder. So I added a option for the parent folder of the plublic dir and the assets.

It would be really great if you could include the changes in your npm package.
