### PR TITLE
correctly resolve patterns against appDir

### DIFF
--- a/lib/nap.coffee
+++ b/lib/nap.coffee
@@ -466,7 +466,7 @@ expandAssetGlobs = =>
     for pkg, patterns of @originalAssets[key]
       matches = []
       for pattern in patterns
-        dirs = glob.sync path.resolve("#{appDir}/#{pattern}").replace(/\\/g, "\/")
+        dirs = glob.sync path.resolve(appDir, pattern).replace(/\\/g, "\/")
         matches = matches.concat(dirs)
       matches = _.uniq _.flatten matches
       matches = (file.replace(appDir, '').replace(/^\//, '') for file in matches)


### PR DESCRIPTION
correctly resolve `pattern` against `appDir` instead of concatenating them.

Using an absolute path in the asset sources, yields empty file, because this line prefixes patterns with `appDir`, instead of properly resolving them.

After fixing this line, files are properly generated when using absolute asset sources.
