### PR TITLE
normalize file path key to make it work on windows

### DIFF
--- a/lib/nap.coffee
+++ b/lib/nap.coffee
@@ -469,7 +469,7 @@ expandAssetGlobs = =>
         dirs = glob.sync path.resolve("#{@appDir}/#{pattern}").replace(/\\/g, "\/")
         matches = matches.concat(dirs)
       matches = _.uniq _.flatten matches
-      matches = (file.replace(@appDir, '').replace(/^\//, '') for file in matches)
+      matches = (path.normalize(file).replace(@appDir, '').replace(/^\//, '').replace(/\\/g, '\/') for file in matches)
       assets[key][pkg] = matches
   @assets = assets
 


### PR DESCRIPTION
release after `0.7.11` seems to have broken nap on windows.

Here are the fixes for windows. (It now works on windows. also tested with mac and seems to work fine.)

Not adding `path.normalize` seems to break windows.

```
ENOENT, no such file or directory 'C:\dumps\test\C:\dumps\test\public\stylesheets\_vendor\bootstrap.min.css'
```

replacing the key is required so `\` gets rendered as `/` in `href` as well as JST key.

``` html
 <link href='/assets/public\stylesheets\_vendor\bootstrap.min.css' rel='stylesheet' type='text/css'>
```

``` js
JST['\admin\index'] = "....";
```
