### PR TITLE
Add filename option to less render

### DIFF
--- a/lib/nap.coffee
+++ b/lib/nap.coffee
@@ -242,7 +242,7 @@ module.exports.preprocessors = preprocessors =
     contents
 
   '.less': (contents, filename) ->
-    require('less').render contents, (err, out) ->
+    require('less').render contents, {filename: filename}, (err, out) ->
       throw(err) if err
       contents = out
     contents

--- a/test/fixtures/1/foo-include.less
+++ b/test/fixtures/1/foo-include.less
@@ -1,0 +1,1 @@
+@import "../1/foo.less";

--- a/test/nap_spec.coffee
+++ b/test/nap_spec.coffee
@@ -318,6 +318,16 @@ describe '#css', ->
       fs.readFileSync(process.cwd() + '/public/assets/test/fixtures/1/foo.css')
         .toString().should.include '#header {\n  color: #4d926f;'
 
+    it 'compiles any less files with imports into css', ->
+      nap
+        assets:
+          css:
+            foo: ['/test/fixtures/1/foo-include.less']
+      nap.css('foo').should
+        .equal "<link href=\'/assets/test/fixtures/1/foo-include.css\' rel=\'stylesheet\' type=\'text/css\'>"
+      fs.readFileSync(process.cwd() + '/public/assets/test/fixtures/1/foo-include.css')
+        .toString().should.include '#header {\n  color: #4d926f;'
+
   describe "in production", ->
 
     it 'returns a link tag pointing to the packaged file', ->


### PR DESCRIPTION
NAP crashes, through less, when trying to include a file like below
when the filename option isn't set.

I'm guessing less will be running everything relative of where NAP is 
being called and as such won't find the file.

``` css
@import "../bower_components/bootstrap/less/bootstrap.less";
```

I tried running the test suite but I get an error so I don't know if the 
test I wrote for this will actually work. But using the cli less compiler
it outputs the expected result and where I use nap also works 
properly now so I assume it works from that.

This is the error I'm getting when running `npm test`:

``` bash
% npm test

> nap@0.7.17 test /Users/ba/Development/nap
> mocha


/Users/ba/Development/nap/test/nap_spec.coffee:1
unction (exports, require, module, __filename, __dirname) { require './helpers
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: Unexpected string
  at Module._compile (module.js:439:25)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at /Users/ba/Development/nap/node_modules/mocha/lib/mocha.js:172:27
  at Array.forEach (native)
  at Mocha.loadFiles (/Users/ba/Development/nap/node_modules/mocha/lib/mocha.js:169:14)
  at Mocha.run (/Users/ba/Development/nap/node_modules/mocha/lib/mocha.js:356:31)
  at Object.<anonymous> (/Users/ba/Development/nap/node_modules/mocha/bin/_mocha:359:16)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:902:3

npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
